### PR TITLE
just return h3 results, not subsites

### DIFF
--- a/google.py
+++ b/google.py
@@ -194,12 +194,12 @@ def search(query, tld='com', lang='en', num=10, start=0, stop=None, pause=2.0):
 
         # Parse the response and process every anchored URL.
         soup = BeautifulSoup(html)
-        anchors = soup.find(id='search').findAll('a')
+        anchors = soup.find(id='search').findAll('h3')
         for a in anchors:
 
             # Get the URL from the anchor tag.
             try:
-                link = a['href']
+                link = a.find('a')['href']
             except KeyError:
                 continue
 


### PR DESCRIPTION
Some sites display additional results from the same page. Your script returns them all. I would find it more intuitive, if only the 10 main results are returned.