### PR TITLE
Compatibility python2/3 on iteritems().

### DIFF
--- a/google/__init__.py
+++ b/google/__init__.py
@@ -258,8 +258,12 @@ def search(query, tld='com', lang='en', tbs='0', safe='off', num=10, start=0,
     # Loop until we reach the maximum result, if any (otherwise, loop forever).
     while not stop or start < stop:
 
+        try:  # Is it python<3?
+            iter_extra_params = extra_params.iteritems()
+        except AttributeError:  # Or python>3?
+            iter_extra_params = extra_params.items()
         # Append extra GET_parameters to URL
-        for k, v in extra_params.iteritems():
+        for k, v in iter_extra_params:
             url += url + ('&%s=%s' % (k, v))
 
         # Sleep between requests.


### PR DESCRIPTION
Hi @MarioVilas, I tried to use your script with python 3.x but got an error on ``.iteritems()`` because python3.x removed all ``.iterXXX()`` methods since ``.items()`` already returns an iterator.

This patch first tries to use ``.iteritems()`` (python2.x) and fallbacks on ``.items()`` (python3.x) if it raises ``AttributeError``.

It would have been possible to use the [``six`` package](https://pythonhosted.org/six/) with ``six.iteritems()`` but I thought that adding one extra dependency for fixing only one occurence of ``.iteritems()`` in your light package would have been overkill.

I'm opened for discussion here.