### PR TITLE
Adding lucky() method for single-URL output (does not use generator);…

### DIFF
--- a/.google-cookie
+++ b/.google-cookie
@@ -1,2 +1,0 @@
-#LWP-Cookies-2.0
-Set-Cookie3: NID="76=LsT7yGmum4D3WGvp4Bn026o4a43nQhRaybR0ZXdIdrA_35svoUWB0GMbUMnk1jXATiV3-BkdQuTYtCt003MN6aFtWMvqUY1A9tOpu4NIGtB90UK7dd9ys75-TM0fc67msQm_qIn6kK5G12Q"; path="/"; domain=".google.com"; path_spec; domain_dot; expires="2016-08-12 08:19:32Z"; HttpOnly=None; version=0

--- a/.google-cookie
+++ b/.google-cookie
@@ -1,0 +1,2 @@
+#LWP-Cookies-2.0
+Set-Cookie3: NID="76=LsT7yGmum4D3WGvp4Bn026o4a43nQhRaybR0ZXdIdrA_35svoUWB0GMbUMnk1jXATiV3-BkdQuTYtCt003MN6aFtWMvqUY1A9tOpu4NIGtB90UK7dd9ys75-TM0fc67msQm_qIn6kK5G12Q"; path="/"; domain=".google.com"; path_spec; domain_dot; expires="2016-08-12 08:19:32Z"; HttpOnly=None; version=0

--- a/google/__init__.py
+++ b/google/__init__.py
@@ -157,7 +157,13 @@ def search_apps(query, tld='com', lang='en', tbs='0', safe='off', num=10, start=
                 stop=None, pause=2.0, only_standard=False, extra_params={}):
     return search(query, tld, lang, tbs, safe, num, start, stop, pause, only_standard, extra_params, tpe='app')
 
-
+# Shortcut to single-item search. Evaluates the iterator to return the single
+# URL as a string.
+def lucky(query, tld='com', lang='en', tbs='0', safe='off', only_standard=False,
+          extra_params={}, tpe=''):
+    gen = search(query, tld, lang, tbs, safe, 1, 0, 1, 0., only_standard, extra_params, tpe)
+    return gen.next()
+    
 # Returns a generator that yields URLs.
 def search(query, tld='com', lang='en', tbs='0', safe='off', num=10, start=0,
            stop=None, pause=2.0, only_standard=False, extra_params={}, tpe=''):
@@ -273,7 +279,7 @@ def search(query, tld='com', lang='en', tbs='0', safe='off', num=10, start=0,
         html = get_page(url)
 
         # Parse the response and process every anchored URL.
-        soup = BeautifulSoup(html)
+        soup = BeautifulSoup(html, 'html.parser')
         anchors = soup.find(id='search').findAll('a')
         for a in anchors:
 

--- a/google/__init__.py
+++ b/google/__init__.py
@@ -162,7 +162,7 @@ def search_apps(query, tld='com', lang='en', tbs='0', safe='off', num=10, start=
 def lucky(query, tld='com', lang='en', tbs='0', safe='off', only_standard=False,
           extra_params={}, tpe=''):
     gen = search(query, tld, lang, tbs, safe, 1, 0, 1, 0., only_standard, extra_params, tpe)
-    return gen.next()
+    return next(gen)
     
 # Returns a generator that yields URLs.
 def search(query, tld='com', lang='en', tbs='0', safe='off', num=10, start=0,


### PR DESCRIPTION
… specified default bs4 parser.

I'm not sure when bs4 started throwing warnings (at least, not after a quick revision scan), but in the use case targeted here--where you simply want to do a quick look-up (particularly for a domain-specific search), the explicit specification of html.parser is a nice feature. I understand this may interfere with the more traditional use cases if users have an interest in non-default parsers; if this is an issue, perhaps a module-level hook or optional parameter could be added?

As for lucky(), it's fairly straight-forward. Several parameters are specified to ensure a) only one result is queried, b) the delay is ignored, and c) the url of that result is returned by evaluating the first instance of the generator. Obviously, what we're shooting for here is a direct, fast-as-possible use case in the tradition of the 'I'm Feeling Lucky' button.

For those who may need an explicit example::

>\> from google import lucky
>\> lucky('site:github.com google') # This returns the Google developer organization page
>u'https://github.com/google'
