### PR TITLE
Move BeautifulSoup Import, fixing UnboundLocalError exception

### DIFF
--- a/google/__init__.py
+++ b/google/__init__.py
@@ -44,8 +44,12 @@ else:
     from urllib2 import Request, urlopen
     from urlparse import urlparse, parse_qs
 
-# Lazy import of BeautifulSoup.
-BeautifulSoup = None
+try:
+    from bs4 import BeautifulSoup
+    is_bs4 = True
+except ImportError:
+    from BeautifulSoup import BeautifulSoup
+    is_bs4 = False
 
 # URL templates to make Google searches.
 url_home = "https://www.google.%(tld)s/"
@@ -163,7 +167,7 @@ def lucky(query, tld='com', lang='en', tbs='0', safe='off', only_standard=False,
           extra_params={}, tpe=''):
     gen = search(query, tld, lang, tbs, safe, 1, 0, 1, 0., only_standard, extra_params, tpe)
     return next(gen)
-    
+
 # Returns a generator that yields URLs.
 def search(query, tld='com', lang='en', tbs='0', safe='off', num=10, start=0,
            stop=None, pause=2.0, only_standard=False, extra_params={}, tpe=''):
@@ -220,18 +224,6 @@ def search(query, tld='com', lang='en', tbs='0', safe='off', num=10, start=0,
     @return: Generator (iterator) that yields found URLs. If the C{stop}
         parameter is C{None} the iterator will loop forever.
     """
-
-    # Lazy import of BeautifulSoup.
-    # Try to use BeautifulSoup 4 if available, fall back to 3 otherwise.
-    global BeautifulSoup
-    if BeautifulSoup is None:
-        try:
-            from bs4 import BeautifulSoup
-            is_bs4 = True
-        except ImportError:
-            from BeautifulSoup import BeautifulSoup
-            is_bs4 = False
-
     # Set of hashes for the results found.
     # This is used to avoid repeated results.
     hashes = set()


### PR DESCRIPTION
This PR moves the BeautifulSoup import to the top of the file, in compliance
with PEP8 and fixing an UnboundLocalError issue with the is_bs4 variable.

Prior to this change, your second call to search() will always fail because
BeautifulSoup is already imported, which means is_bs4 variable never gets
instantiated within the second call to the function (since the BeautifulSoup variable is no longer None).

When we get this PR merged, can you please release a new version to PyPI?
Thanks!